### PR TITLE
Bump PHP to ^8.3

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -13,12 +13,8 @@ jobs:
       max-parallel: 3
       matrix:
         php:
-          - 7.3
-          - 7.4
-          - 8.0
-          - 8.1
-          - 8.2
           - 8.3
+          - 8.4
         composer: 
           - 2  
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Rewritten smarty 'include' variant that was invented for use in XOOPS, but nowadays is used in some other PHP based CMS'es",
     "type": "library",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.3",
         "imponeer/smarty-extensions-contracts": "^3.0"
     },
     "license": "MIT",
@@ -16,6 +16,11 @@
     "autoload": {
         "psr-4": {
             "Imponeer\\Smarty\\Extensions\\IncludeQ\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Imponeer\\Smarty\\Extensions\\IncludeQ\\Tests\\": "tests/"
         }
     },
     "keywords": [

--- a/src/IncludeQCompiler.php
+++ b/src/IncludeQCompiler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Imponeer\Smarty\Extensions\IncludeQ;
 
@@ -53,7 +54,7 @@ class IncludeQCompiler implements SmartyCompilerInterface
      *
      * @throws SmartyCompilerException
      */
-    protected function validateArguments(array $args, Smarty_Internal_SmartyTemplateCompiler $compiler)
+    protected function validateArguments(array $args, Smarty_Internal_SmartyTemplateCompiler $compiler): void
     {
         if (!isset($args['file'])) {
             $compiler->trigger_template_error(

--- a/tests/IncludeQCompilerTest.php
+++ b/tests/IncludeQCompilerTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Imponeer\Smarty\Extensions\IncludeQ\IncludeQCompiler;
 use PHPUnit\Framework\TestCase;
@@ -6,10 +7,7 @@ use PHPUnit\Framework\TestCase;
 class IncludeQCompilerTest extends TestCase
 {
 
-    /**
-     * @var Smarty
-     */
-    private $smarty;
+    private Smarty $smarty;
 
     protected function setUp(): void
     {
@@ -26,14 +24,16 @@ class IncludeQCompilerTest extends TestCase
         parent::setUp();
     }
 
-    public function testGetName() {
+    public function testGetName(): void
+    {
         $this->assertSame(
             'includeq',
             $this->plugin->getName()
         );
     }
 
-    public function testInvoking() {
+    public function testInvoking(): void
+    {
         $src = urlencode(
             sprintf(
                 "{includeq file=\"%s\"}",


### PR DESCRIPTION
Resolves #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported PHP versions to 8.3 and 8.4 in testing and composer configuration.
  * Enabled strict typing in relevant files.
  * Improved type declarations for properties and method signatures.
  * Added PSR-4 autoloading for test classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->