### PR TITLE
Bump PHPUnit to ^12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "smarty-plugins"
     ],
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "phpunit/phpunit": "^12.0"
     },
     "scripts": {
         "test": "phpunit --testdox"

--- a/tests/IncludeQCompilerTest.php
+++ b/tests/IncludeQCompilerTest.php
@@ -8,6 +8,7 @@ class IncludeQCompilerTest extends TestCase
 {
 
     private Smarty $smarty;
+    private IncludeQCompiler $plugin;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Resolves #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency to require PHPUnit version 12.

* **Tests**
  * Improved test setup by introducing a dedicated property for the compiler plugin in unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->